### PR TITLE
Correcciones generar.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+compartir/datasets/imagenes/*
+compartir/**/*.tar.gz
+compartir/**/suma_verificacion.txt

--- a/compartir/scripts/generar.sh
+++ b/compartir/scripts/generar.sh
@@ -1,24 +1,28 @@
 #!/bin/bash
 
+RUTA_DATASETS=$(pwd)compartir/datasets/
+
 generar() {
     while true; do
         read -p "Ingresa el número de imágenes a generar: (-1 para volver)" NUM
         if [[ $NUM == "-1" ]]; then
             break
-        elif [[ $NUM =~ ^[0-9]+$ && $NUM -gt 0]]; then #Valida que sea un número entero positivo
+        elif [[ $NUM =~ ^[0-9]+$ && $NUM -gt 0 ]]; then #Valida que sea un número entero positivo
             LINK="https://source.unsplash.com/random/900%C3%97700/?person"
+            mkdir -p ${RUTA_DATASETS}imagenes # Crea el directorio 'imagenes' si no existe
+            
             for ((i=1; i<=$NUM; i++)); do
-                NOMBRE=$(sed -n "$RANDOM p" datasets/nombres) #Elige un nombre aleatorio de una lista de nombres
+                NOMBRE=$(sed -n "$RANDOM p" ${RUTA_DATASETS}nombres.csv) #Elige un nombre aleatorio de una lista de nombres
 	            NOMBRE=$(echo $NOMBRE | cut -d ',' -f 1) #Toma lo que esta antes de la coma (Aaron Damian,85 -> Aaron Damian)
-	            NOMBRE=$(echo $NOMBRE | tr -d ' ') #Quita los espacios dentro del nombre (Aaron Damian -> AaronDamian)
+                NOMBRE=$(echo $NOMBRE | cut -d ' ' -f 1) #Corta los espacios dentro del nombre (Aaron Damian -> Aaron)
 
-                wget "$LINK" -O "datasets/imagenes/$NOMBRE.jpg" #Genera una imagen y la guarda en la carpeta 'imagenes'
+                wget "$LINK" -O "${RUTA_DATASETS}imagenes/$NOMBRE.jpg" #Genera una imagen y la guarda en la carpeta 'imagenes'
                 echo "Descargando la imagen numero $i..."
                 sleep 1 #Espera entre descarga y descarga para no saturar el servicio
             done
             echo "Imágenes generadas. Comprimiendo..."
-            tar -czf datasets/imagenes.tar.gz -C datasets/imagenes #Comprime las imagenes generadas
-            md5sum datasets/imagenes.tar.gz > suma_verificacion.txt #Genera el archivo de suma de verificación
+            tar -czf ${RUTA_DATASETS}imagenes.tar.gz -C ${RUTA_DATASETS}imagenes *.jpg #Comprime las imagenes generadas
+            md5sum ${RUTA_DATASETS}imagenes.tar.gz > ${RUTA_DATASETS}suma_verificacion.txt #Genera el archivo de suma de verificación
             echo "Imágenes comprimidas. Suma de verificación generada."
         else
             echo "Ingresa un número válido"


### PR DESCRIPTION
- [x] se agrega una ruta base RUTA_DATASETS=$(pwd)compartir/datasets/ teniendo en cuenta que el script se ejecuta en "/"
- [x] se corrigió un error de sintaxis en la linea de elif 
- [x] el nombre de las imagenes ahora se corta en el espacio en blanco (debatir si es correcto)
- [x] la. funcion generar() ahora crea el directorio "imagenes" si este no existe
- [x] se agregó el archivo .gitignore para evitar el seguimiento de imagenes, etc.